### PR TITLE
LSP has its own environment, removing the need for user to install any packages

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -11,11 +11,7 @@ export async function activate(context: ExtensionContext): Promise<void> {
     return;
   }
 
-  const missing = await ctx.resolveMissingPkgs();
-  if (missing.length) {
-    workspace.showMessage(`Julia module missing: ${missing.toString()}. You need to install them first.`, 'warning');
-    return;
-  }
+  ctx.fixMissingPkgs();
 
   await ctx.startServer();
 }


### PR DESCRIPTION
Hi,
I've previously used the language server manually and put in this neat tweak, so I though I'd share it with others

With this PR, a new julia environment is created at `~/.config/coc/julia-environment` and on first use, any packages are added to it. So, the user does not have to worry about having the correct Julia packages installed in their system and in their global environment.

- [ ] This will probably crash on Windows as the environment path doesn't exist - is there any good place for it?
- [ ] I didn't have the opportunity to test this because of #14
- [ ] For future: I'd be super neat if the packages would auto-update in the background after the LSP is started - that's probably beyond my skills...