### PR TITLE
Wrap LanguageServer tests in `try catch`

### DIFF
--- a/server/src/exec.jl
+++ b/server/src/exec.jl
@@ -2,5 +2,9 @@ using Pkg
 using LanguageServer
 using LanguageServer.JuliaFormatter
 
-Pkg.test("LanguageServer")
+try
+  Pkg.test("LanguageServer")
+catch
+end
+
 JuliaFormatter.format(@__FILE__)


### PR DESCRIPTION
I looks like some of the tests for LanguageServer.jl fail, even for the tagged release. In that case, compilation is aborted and I don't get a system image. Thus, I propose to catch any exception thrown by the test suit.